### PR TITLE
Enabled use of S3-hosted private repositories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /checkouts
 /.lein-deps-sum
 target/
+.nrepl-port
+

--- a/src/leiningen/deploy_uberjar.clj
+++ b/src/leiningen/deploy_uberjar.clj
@@ -22,6 +22,7 @@
 (defn add-auth-interactively [[id settings]]
   (if (or (and (:username settings) (some settings [:password :passphrase
                                                     :private-key-file]))
+          (:no-auth settings)
           (.startsWith (:url settings) "file://"))
     [id settings]
     (do
@@ -40,7 +41,8 @@
                          :when (= id name)] settings)]
     (-> [name settings]
         (classpath/add-repo-auth)
-        (add-auth-interactively))))
+        ;; (add-auth-interactively)
+        )))
 
 (defn sign [file]
   (let [exit (binding [*out* (java.io.StringWriter.)]

--- a/src/leiningen/deploy_uberjar.clj
+++ b/src/leiningen/deploy_uberjar.clj
@@ -41,7 +41,7 @@
                          :when (= id name)] settings)]
     (-> [name settings]
         (classpath/add-repo-auth)
-        ;; (add-auth-interactively)
+        (add-auth-interactively)
         )))
 
 (defn sign [file]

--- a/src/leiningen/deploy_uberjar.clj
+++ b/src/leiningen/deploy_uberjar.clj
@@ -22,6 +22,8 @@
 (defn add-auth-interactively [[id settings]]
   (if (or (and (:username settings) (some settings [:password :passphrase
                                                     :private-key-file]))
+          ;; No auth may be set  by wagon plugins (e.g. s3-wagon-private) that
+          ;; require credentials of type not natively supported by Leiningen.
           (:no-auth settings)
           (.startsWith (:url settings) "file://"))
     [id settings]


### PR DESCRIPTION
In function add-auth-interactively, added a check for the :no-auth key in the repository credentials map. Some wagon plugins require access credentials, but use authentication mechanisms not natively supported by lein, e.g. the AWS credentials provider chain. With this change I was able to successfully deploy fat jars to a S3 bucket, using the credentials as conventionally stored for AWS utilities (through this wagon: https://github.com/s3-wagon-private/s3-wagon-private).